### PR TITLE
Fixed Awk missing operand

### DIFF
--- a/mt_prep_gmtsar_SB
+++ b/mt_prep_gmtsar_SB
@@ -43,7 +43,7 @@ ln -f -s $topo/master.PRM .
 
 # read azimuth heading angle from the master image
 if [ $heading == auto ]; then
-heading=$(grep platformHeading $raw_orig/*$master_date*.xml | awk -F">||<" '{print $3}')
+heading=$(grep platformHeading $raw_orig/*$master_date*.xml | awk -F"[>||<]" '{print $3}')
 fi
 
 p=1

--- a/mt_prep_gmtsar_SM
+++ b/mt_prep_gmtsar_SM
@@ -43,7 +43,7 @@ ln -f -s $topo/master.PRM .
 
 # read azimuth heading angle from the master image
 if [ $heading == auto ]; then
-heading=$(grep platformHeading $raw_orig/*$master_date*.xml | awk -F">||<" '{print $3}')
+heading=$(grep platformHeading $raw_orig/*$master_date*.xml | awk -F"[>||<]" '{print $3}')
 fi
 
 p=1


### PR DESCRIPTION
Fixed awk: line 0: regular expression compile failed (missing operand)
\>||<

This would cause nothing to be written to the heading file and some other issues